### PR TITLE
changed ProductCard, that the rating stars are visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 ### Fixed
 ### Removed
 
+## [3.2.0]
+### Changed
+- changed `ProductCard` component from hiding rating to not hiding rating
+
 ## [3.1.4]
 ### Added
 - add `upselling` class to the tablet-adjustments

--- a/frontend/components/Item/index.jsx
+++ b/frontend/components/Item/index.jsx
@@ -45,7 +45,6 @@ const Item = ({
             product={product}
             hideName={!showName}
             hidePrice={!showPrice}
-            hideRating
             titleRows={titleRows}
           />
         </ProductContext.Provider>


### PR DESCRIPTION
# Pull Request Template

## Description

Changed the ProductCard component's props, that the rating stars are visible in the upselling slider.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
