### PR TITLE
Add config for toggling the ratings star

### DIFF
--- a/extension-config.json
+++ b/extension-config.json
@@ -46,6 +46,16 @@
         "label": "Product page add to cart settings (see README)",
         "required": false
       }
+    },
+    "hideRatingStars":{
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "boolean",
+        "label": "toggle the visibilty of ratings on product slider",
+        "required": false
+      }
     }
   }
 }

--- a/frontend/components/Item/index.jsx
+++ b/frontend/components/Item/index.jsx
@@ -5,6 +5,7 @@ import { Card } from '@shopgate/engage/components';
 import { ProductCard as ProductCardBase } from '@shopgate/engage/product';
 import PlaceholderCard from './components/PlaceholderCard';
 import getStyles from '../../styles/slider';
+import getConfig from '../../helpers/getConfig';
 
 const styles = getStyles();
 
@@ -23,8 +24,8 @@ const Item = ({
   showPrice,
   titleRows,
 }) => {
+ const { hideRatingStars } = getConfig();
   const { contexts: { ProductContext } } = useContext(ThemeContext);
-
   let ProductCard = ProductCardBase;
 
   // Show a placeholder if product is not yet available.
@@ -46,6 +47,7 @@ const Item = ({
             hideName={!showName}
             hidePrice={!showPrice}
             titleRows={titleRows}
+            hideRating={hideRatingStars}
           />
         </ProductContext.Provider>
       </Card>


### PR DESCRIPTION

## Description
Add a config variable for toggling the ratings star visibility on the product slider description 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] This change requires a documentation update