### PR TITLE
bugfix for products from props wasn't fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 ### Fixed
 ### Removed
 
+## [3.4.1]
+### Fixed
+- fixed a bug where products from properties wasn't fetched
+
 ## [3.4.0]
 ### Changed
 - added configuration `hideRatingStars` to toggle rating stars

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.0",
+  "version": "3.4.1",
   "id": "@shopgate/upselling",
   "components": [
     {

--- a/frontend/components/Slider/index.jsx
+++ b/frontend/components/Slider/index.jsx
@@ -11,6 +11,7 @@ import {
 import DefaultSlider from './components/DefaultSlider';
 import getStyles from '../../styles/slider';
 import { TYPE_PROPERTY } from '../../helpers/constants';
+import { fetchProductsById } from '@shopgate/pwa-common-commerce/product';
 
 const styles = getStyles();
 
@@ -67,6 +68,16 @@ class Slider extends Component {
         allowPlaceholders: false,
       });
     }, 3000);
+  }
+
+  /**
+   * Fetches the products from properties on component did update
+   */
+  componentDidUpdate() {
+    const { dispatch, type, productIds } = this.props;
+    if (type === TYPE_PROPERTY) {
+      dispatch(fetchProductsById(productIds))
+    }
   }
 
   /**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/upselling",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed a bug where the products from properties wasn't fetched. Now the products get fetched on component did update. (after the productIds got loaded from the products properties)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
